### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/components/file-upload.js
+++ b/src/js/components/file-upload.js
@@ -52,10 +52,13 @@ function initializeKromaFileUploadComponents() {
         function appendFileToList(file, listContainer) {
             const listItem = document.createElement('div');
             listItem.className = 'kroma-file-upload-list-item';
-            listItem.innerHTML = `
-                <span>${file.name}</span>
-                <button aria-label="Remove file">&times;</button>
-            `;
+            const fileNameSpan = document.createElement('span');
+            fileNameSpan.textContent = file.name;
+            const removeButton = document.createElement('button');
+            removeButton.setAttribute('aria-label', 'Remove file');
+            removeButton.textContent = '×';
+            listItem.appendChild(fileNameSpan);
+            listItem.appendChild(removeButton);
             // Handle remove file
             listItem.querySelector('button').addEventListener('click', () => {
                 listItem.remove();


### PR DESCRIPTION
Fixes [https://github.com/altxriainc/kromacss/security/code-scanning/1](https://github.com/altxriainc/kromacss/security/code-scanning/1)

To fix the problem, we need to ensure that any text inserted into the HTML is properly escaped to prevent XSS attacks. Instead of using `innerHTML`, which can interpret the text as HTML, we should use `textContent` to safely insert the text as plain text.

- Replace the use of `innerHTML` with `textContent` for inserting the file name.
- Ensure that the button element is created and appended separately to avoid using `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
